### PR TITLE
Change chunk size

### DIFF
--- a/src/main/kotlin/net/axay/kspigot/extensions/bukkit/GeoExtensions.kt
+++ b/src/main/kotlin/net/axay/kspigot/extensions/bukkit/GeoExtensions.kt
@@ -18,7 +18,7 @@ val Location.worldOrException: World
  */
 val Chunk.allBlocks
     get() = LinkedHashSet<Block>().apply {
-        for (y in 0 until 256) {
+        for (y in -64 until 320) {
             for (x in 0 until 16)
                 for (z in 0 until 16)
                     add(getBlock(x, y, z))


### PR DESCRIPTION
Currently the Chunk.allBlocks extension only works 100% in 1.17.1 or lower