### PR TITLE
Location to short String

### DIFF
--- a/src/main/kotlin/net/axay/kspigot/extensions/geometry/KSpigotLocations.kt
+++ b/src/main/kotlin/net/axay/kspigot/extensions/geometry/KSpigotLocations.kt
@@ -45,3 +45,4 @@ fun SimpleLocation3D.toVector() = Vector(x, y, z)
  * Returns a simple string in the format of `[x, y, z]`.
  */
 fun Location.toSimpleString() = "[$x, $y, $z]"
+fun Location.toSimpleBlockString() = "[$blockX, $blockY, $blockZ]"


### PR DESCRIPTION
Turn a location in a simple and short string. No decimal numbers like in Location.toSimpleString()