### PR TITLE
Bump to mc 1.20.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val githubRepo = "jakobkmar/KSpigot"
 
 group = "net.axay"
-version = "1.20.2"
+version = "1.20.3"
 
 description = "A Kotlin API for Minecraft plugins using the Spigot or Paper toolchain"
 
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.20.2-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")
 
     api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")

--- a/src/main/kotlin/net/axay/kspigot/commands/internal/BrigardierSupport.kt
+++ b/src/main/kotlin/net/axay/kspigot/commands/internal/BrigardierSupport.kt
@@ -33,7 +33,7 @@ object BrigardierSupport {
     }
 
     @Suppress("HasPlatformType")
-    fun resolveCommandManager() = (server as org.bukkit.craftbukkit.v1_20_R2.CraftServer)
+    fun resolveCommandManager() = (server as org.bukkit.craftbukkit.v1_20_R3.CraftServer)
         .server.vanillaCommandDispatcher
 
     internal fun registerAll() {
@@ -52,7 +52,7 @@ object BrigardierSupport {
     fun updateCommandTree() {
         onlinePlayers.forEach {
             // send the command tree
-            resolveCommandManager().sendCommands((it as org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer).handle)
+            resolveCommandManager().sendCommands((it as org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer).handle)
         }
     }
 }

--- a/src/main/kotlin/net/axay/kspigot/data/NBTDataLoader.kt
+++ b/src/main/kotlin/net/axay/kspigot/data/NBTDataLoader.kt
@@ -4,8 +4,8 @@ package net.axay.kspigot.data
 
 import net.axay.kspigot.annotations.NMS_General
 import net.minecraft.nbt.CompoundTag
-import org.bukkit.craftbukkit.v1_20_R2.entity.CraftEntity
-import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
 import org.bukkit.entity.Entity
 import org.bukkit.inventory.ItemStack
 

--- a/src/main/kotlin/net/axay/kspigot/extensions/bukkit/EntityExtensions.kt
+++ b/src/main/kotlin/net/axay/kspigot/extensions/bukkit/EntityExtensions.kt
@@ -138,8 +138,8 @@ fun Player.showOnlinePlayers() {
 @Deprecated("This function is unstable and it cannot be guaranteed that it will work at any time in the future.")
 @NMS_General
 fun Location.spawnCleanEntity(entityType: EntityType): Entity? {
-    val craftWorld = world as? org.bukkit.craftbukkit.v1_20_R2.CraftWorld ?: return null
-    return craftWorld.createEntity(this, entityType.entityClass)?.let {
+    val craftWorld = world as? org.bukkit.craftbukkit.v1_20_R3.CraftWorld ?: return null
+    return craftWorld.makeEntity(this, entityType.entityClass!!)?.let {
         craftWorld.handle.addFreshEntity(it)
         return@let it.bukkitEntity
     }
@@ -197,7 +197,7 @@ fun Player.give(vararg itemStacks: ItemStack) = inventory.addItem(*itemStacks)
  * Adds all equipment locks to every equipment slot
  */
 fun ArmorStand.fullLock() {
-    for (slot in EquipmentSlot.values()) {
+    for (slot in EquipmentSlot.entries) {
         lock(slot)
     }
 }
@@ -207,7 +207,7 @@ fun ArmorStand.fullLock() {
  * @param slot the slot which gets locked
  */
 fun ArmorStand.lock(slot: EquipmentSlot) {
-    for (lock in ArmorStand.LockType.values()) {
+    for (lock in ArmorStand.LockType.entries) {
         addEquipmentLock(slot, lock)
     }
 }

--- a/src/main/kotlin/net/axay/kspigot/structures/Structure.kt
+++ b/src/main/kotlin/net/axay/kspigot/structures/Structure.kt
@@ -10,7 +10,7 @@ import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.block.data.BlockData
-import org.bukkit.craftbukkit.v1_20_R2.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 


### PR DESCRIPTION
- Bump paperweight/bukkit version to 1.20.4
  - Changed Location.spawnCleanEntity according to method-name change in craftbukkit api
- Change .values() to .entries for iterating over enums