### PR TITLE
Fix unregistering the wrong GUI on InventoryCloseEvent

### DIFF
--- a/src/main/java/net/axay/kspigot/chat/KColors.java
+++ b/src/main/java/net/axay/kspigot/chat/KColors.java
@@ -3,7 +3,6 @@ package net.axay.kspigot.chat;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/kotlin/net/axay/kspigot/gui/GUI.kt
+++ b/src/main/kotlin/net/axay/kspigot/gui/GUI.kt
@@ -99,7 +99,9 @@ class GUIIndividual<T : ForInventory>(
     init {
         if (resetOnClose || data.onClose != null) {
             listen<InventoryCloseEvent> {
-                if (data.onClose != null && playerInstances[it.player]?.bukkitInventory == it.inventory) {
+                 if (playerInstances[it.player]?.bukkitInventory != it.inventory) return@listen
+
+                if (data.onClose != null) {
                     data.onClose.invoke(GUICloseEvent(it, playerInstances[it.player]!!, it.player as Player))
                 }
 

--- a/src/main/kotlin/net/axay/kspigot/gui/GUI.kt
+++ b/src/main/kotlin/net/axay/kspigot/gui/GUI.kt
@@ -99,7 +99,7 @@ class GUIIndividual<T : ForInventory>(
     init {
         if (resetOnClose || data.onClose != null) {
             listen<InventoryCloseEvent> {
-                 if (playerInstances[it.player]?.bukkitInventory != it.inventory) return@listen
+                if (playerInstances[it.player]?.bukkitInventory != it.inventory) return@listen
 
                 if (data.onClose != null) {
                     data.onClose.invoke(GUICloseEvent(it, playerInstances[it.player]!!, it.player as Player))


### PR DESCRIPTION
Previously, only the `onClose` callback checked if the inventory closed was the correct one. However, it called `deleteInstance` on every InventoryCloseEvent, which caused an issue with `GUIPageBuilder#changeGUI` (#64). This was because the InventoryCloseEvent was triggered after the GUI changed, leading to the unregistration of the newly opened GUI instead of the old one.

(also removed an unused import in KColors)